### PR TITLE
Add initial Go cache module

### DIFF
--- a/go/core/cache.go
+++ b/go/core/cache.go
@@ -1,0 +1,22 @@
+package core
+
+// Cache provides a simple in-memory cache for prompts and answers.
+type Cache struct {
+	data map[string]string
+}
+
+// NewCache creates a new Cache instance.
+func NewCache() *Cache {
+	return &Cache{data: make(map[string]string)}
+}
+
+// Set stores an answer for the given prompt.
+func (c *Cache) Set(prompt, answer string) {
+	c.data[prompt] = answer
+}
+
+// Get returns the cached answer for a prompt and whether it was found.
+func (c *Cache) Get(prompt string) (string, bool) {
+	val, ok := c.data[prompt]
+	return val, ok
+}

--- a/go/core/cache_test.go
+++ b/go/core/cache_test.go
@@ -1,0 +1,11 @@
+package core
+
+import "testing"
+
+func TestCacheSetGet(t *testing.T) {
+	c := NewCache()
+	c.Set("hello", "world")
+	if val, ok := c.Get("hello"); !ok || val != "world" {
+		t.Fatalf("expected world, got %v, found %v", val, ok)
+	}
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/raja-aiml/sematic-cache/go
+
+go 1.23.8


### PR DESCRIPTION
## Summary
- start Go migration with `go` module
- implement basic `Cache` struct in `core` package
- add simple unit test for the cache

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684b47801b0083259075d4e32d517fda