### PR TITLE
Add Go MVP components

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,3 +400,16 @@ Coming soon! [Stay tuned!](https://twitter.com/zilliz_universe)
 We are extremely open to contributions, be it through new features, enhanced infrastructure, or improved documentation.
 
 For comprehensive instructions on how to contribute, please refer to our [contribution guide](docs/contributing.md).
+
+## Go Server
+
+A minimal Go server is available under `go/cmd/server`. Build and run with:
+
+```bash
+cd go
+go build ./cmd/server
+./server -address :8080
+```
+
+Use `POST /set` and `POST /get` endpoints to store and retrieve answers.
+

--- a/go/cmd/server/main.go
+++ b/go/cmd/server/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"flag"
+	"github.com/raja-aiml/sematic-cache/go/core"
+	"github.com/raja-aiml/sematic-cache/go/server"
+)
+
+func main() {
+	addr := flag.String("address", ":8080", "server address")
+	flag.Parse()
+
+	cache := core.NewCache()
+	srv := server.New(cache)
+	srv.Run(*addr)
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,3 +1,7 @@
 module github.com/raja-aiml/sematic-cache/go
 
 go 1.23.8
+
+require (
+)
+

--- a/go/openai/client.go
+++ b/go/openai/client.go
@@ -1,0 +1,70 @@
+package openai
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Client wraps OpenAI API calls.
+type Client struct {
+	APIKey     string
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+// NewClient creates a new OpenAI client.
+func NewClient(apiKey string) *Client {
+	return &Client{
+		APIKey:     apiKey,
+		BaseURL:    "https://api.openai.com/v1",
+		HTTPClient: &http.Client{},
+	}
+}
+
+// CompletionRequest holds the request body for completions.
+type CompletionRequest struct {
+	Model  string `json:"model"`
+	Prompt string `json:"prompt"`
+}
+
+// CompletionResponse holds the response body for completions.
+type CompletionResponse struct {
+	Choices []struct {
+		Text string `json:"text"`
+	} `json:"choices"`
+}
+
+// Complete calls OpenAI's completion API.
+func (c *Client) Complete(prompt string) (string, error) {
+	reqBody, err := json.Marshal(CompletionRequest{Model: "text-davinci-003", Prompt: prompt})
+	if err != nil {
+		return "", err
+	}
+	req, err := http.NewRequest("POST", c.BaseURL+"/completions", bytes.NewBuffer(reqBody))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("openai: unexpected status %s", resp.Status)
+	}
+
+	var res CompletionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+		return "", err
+	}
+	if len(res.Choices) == 0 {
+		return "", fmt.Errorf("openai: no choices returned")
+	}
+	return res.Choices[0].Text, nil
+}

--- a/go/openai/client_test.go
+++ b/go/openai/client_test.go
@@ -1,0 +1,39 @@
+package openai
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestComplete(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req CompletionRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("bad request: %v", err)
+		}
+		if req.Prompt != "hello" {
+			t.Fatalf("expected prompt hello, got %s", req.Prompt)
+		}
+		resp := CompletionResponse{Choices: []struct {
+			Text string `json:"text"`
+		}{
+			{Text: "world"},
+		}}
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	c := NewClient("test")
+	c.BaseURL = server.URL
+	got, err := c.Complete("hello")
+	if err != nil {
+		t.Fatalf("Complete returned error: %v", err)
+	}
+	if got != "world" {
+		t.Fatalf("expected world, got %s", got)
+	}
+}

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/raja-aiml/sematic-cache/go/core"
+)
+
+// Server provides HTTP access to the cache.
+type Server struct {
+	Cache *core.Cache
+	mux   *http.ServeMux
+}
+
+// New returns a new Server instance with default routes.
+func New(c *core.Cache) *Server {
+	s := &Server{Cache: c, mux: http.NewServeMux()}
+	s.routes()
+	return s
+}
+
+func (s *Server) routes() {
+	s.mux.HandleFunc("/get", s.handleGet)
+	s.mux.HandleFunc("/set", s.handleSet)
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mux.ServeHTTP(w, r)
+}
+
+func (s *Server) handleGet(w http.ResponseWriter, r *http.Request) {
+	var req struct{ Prompt string }
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	val, ok := s.Cache.Get(req.Prompt)
+	if !ok {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	json.NewEncoder(w).Encode(map[string]string{"answer": val})
+}
+
+func (s *Server) handleSet(w http.ResponseWriter, r *http.Request) {
+	var req struct{ Prompt, Answer string }
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.Cache.Set(req.Prompt, req.Answer)
+	w.WriteHeader(http.StatusCreated)
+}
+
+// Run starts the HTTP server.
+func (s *Server) Run(addr string) error {
+	log.Printf("server listening on %s", addr)
+	return http.ListenAndServe(addr, s)
+}

--- a/go/server/server_test.go
+++ b/go/server/server_test.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/raja-aiml/sematic-cache/go/core"
+)
+
+func TestServerSetGet(t *testing.T) {
+	cache := core.NewCache()
+	srv := New(cache)
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// set value
+	body, _ := json.Marshal(map[string]string{"prompt": "p", "answer": "a"})
+	resp, err := http.Post(ts.URL+"/set", "application/json", bytes.NewBuffer(body))
+	if err != nil || resp.StatusCode != http.StatusCreated {
+		t.Fatalf("set failed: %v %v", err, resp.Status)
+	}
+
+	// get value
+	body, _ = json.Marshal(map[string]string{"prompt": "p"})
+	resp, err = http.Post(ts.URL+"/get", "application/json", bytes.NewBuffer(body))
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	var data map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if data["answer"] != "a" {
+		t.Fatalf("expected a, got %s", data["answer"])
+	}
+}

--- a/go/storage/pgstore.go
+++ b/go/storage/pgstore.go
@@ -1,0 +1,66 @@
+package storage
+
+import (
+	"database/sql"
+)
+
+// scanner defines the minimal interface for sql.Row
+// so it can be mocked in tests.
+type scanner interface {
+	Scan(dest ...interface{}) error
+}
+
+// function variables for testability
+var (
+	execFunc = func(db *sql.DB, query string, args ...interface{}) (sql.Result, error) {
+		return db.Exec(query, args...)
+	}
+	queryRowFunc = func(db *sql.DB, query string, args ...interface{}) scanner {
+		return db.QueryRow(query, args...)
+	}
+)
+
+// PGStore stores prompts and answers in PostgreSQL.
+type PGStore struct {
+	db *sql.DB
+}
+
+// NewPGStore opens a PostgreSQL connection.
+func NewPGStore(conn string) (*PGStore, error) {
+	db, err := sql.Open("postgres", conn)
+	if err != nil {
+		return nil, err
+	}
+	return &PGStore{db: db}, nil
+}
+
+// Init creates the table if it doesn't exist.
+func (s *PGStore) Init() error {
+	_, err := execFunc(s.db, `CREATE TABLE IF NOT EXISTS cache (
+        prompt TEXT PRIMARY KEY,
+        embedding VECTOR(1536),
+        answer TEXT
+    )`)
+	return err
+}
+
+// Set inserts or updates a cached answer.
+func (s *PGStore) Set(prompt string, embedding []float32, answer string) error {
+	_, err := execFunc(s.db, `INSERT INTO cache(prompt, embedding, answer)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (prompt) DO UPDATE SET embedding = EXCLUDED.embedding, answer = EXCLUDED.answer`, prompt, embedding, answer)
+	return err
+}
+
+// Get retrieves the answer for a prompt.
+func (s *PGStore) Get(prompt string) (string, bool, error) {
+	row := queryRowFunc(s.db, `SELECT answer FROM cache WHERE prompt = $1`, prompt)
+	var ans string
+	if err := row.Scan(&ans); err != nil {
+		if err == sql.ErrNoRows {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return ans, true, nil
+}

--- a/go/storage/pgstore_test.go
+++ b/go/storage/pgstore_test.go
@@ -1,0 +1,71 @@
+package storage
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+)
+
+type fakeResult struct{}
+
+func (fakeResult) LastInsertId() (int64, error) { return 0, nil }
+func (fakeResult) RowsAffected() (int64, error) { return 0, nil }
+
+type fakeScanner struct {
+	answer string
+	err    error
+}
+
+func (f fakeScanner) Scan(dest ...interface{}) error {
+	if f.err != nil {
+		return f.err
+	}
+	if len(dest) != 1 {
+		return errors.New("dest len")
+	}
+	ptr, ok := dest[0].(*string)
+	if !ok {
+		return errors.New("type")
+	}
+	*ptr = f.answer
+	return nil
+}
+
+type fakeDB struct {
+	expectedPrompt string
+	answer         string
+}
+
+func (f *fakeDB) Exec(query string, args ...interface{}) (sql.Result, error) {
+	return fakeResult{}, nil
+}
+
+func (f *fakeDB) QueryRow(query string, args ...interface{}) scanner {
+	if len(args) > 0 && args[0] == f.expectedPrompt {
+		return fakeScanner{answer: f.answer}
+	}
+	return fakeScanner{err: sql.ErrNoRows}
+}
+
+func TestPGStoreSetGet(t *testing.T) {
+	db := &fakeDB{expectedPrompt: "p", answer: "a"}
+	// override funcs
+	oldExec := execFunc
+	oldQuery := queryRowFunc
+	execFunc = func(_ *sql.DB, q string, args ...interface{}) (sql.Result, error) {
+		return db.Exec(q, args...)
+	}
+	queryRowFunc = func(_ *sql.DB, q string, args ...interface{}) scanner {
+		return db.QueryRow(q, args...)
+	}
+	defer func() { execFunc = oldExec; queryRowFunc = oldQuery }()
+
+	store := &PGStore{}
+	if err := store.Set("p", nil, "a"); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+	val, ok, err := store.Get("p")
+	if err != nil || !ok || val != "a" {
+		t.Fatalf("Get failed: %v %v %v", val, ok, err)
+	}
+}


### PR DESCRIPTION
## Summary
- implement basic OpenAI client
- implement PG storage layer with function hooks for tests
- implement HTTP server package and cmd entrypoint
- document how to build and run the Go server
- add unit tests for new Go packages

## Testing
- `go vet ./...`
- `go test ./...`
- `pytest -q` *(fails: 68 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684b482fe33483259f89a2a0aa571f95