### PR TITLE
Add concurrent Go cache and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,3 +413,12 @@ go build ./cmd/server
 
 Use `POST /set` and `POST /get` endpoints to store and retrieve answers.
 
+### Simple Go Example
+
+For a minimal in-memory example run:
+
+```bash
+go run ./go/examples/simple
+```
+This prints `cached: world` after storing and retrieving a value using the new concurrent cache.
+

--- a/go/core/cache.go
+++ b/go/core/cache.go
@@ -1,7 +1,10 @@
 package core
 
-// Cache provides a simple in-memory cache for prompts and answers.
+import "sync"
+
+// Cache provides a concurrent in-memory cache for prompts and answers.
 type Cache struct {
+	mu   sync.RWMutex
 	data map[string]string
 }
 
@@ -12,11 +15,15 @@ func NewCache() *Cache {
 
 // Set stores an answer for the given prompt.
 func (c *Cache) Set(prompt, answer string) {
+	c.mu.Lock()
 	c.data[prompt] = answer
+	c.mu.Unlock()
 }
 
 // Get returns the cached answer for a prompt and whether it was found.
 func (c *Cache) Get(prompt string) (string, bool) {
+	c.mu.RLock()
 	val, ok := c.data[prompt]
+	c.mu.RUnlock()
 	return val, ok
 }

--- a/go/core/cache_test.go
+++ b/go/core/cache_test.go
@@ -9,3 +9,18 @@ func TestCacheSetGet(t *testing.T) {
 		t.Fatalf("expected world, got %v, found %v", val, ok)
 	}
 }
+
+func TestCacheConcurrent(t *testing.T) {
+	c := NewCache()
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 1000; i++ {
+			c.Set("k", "v")
+		}
+		close(done)
+	}()
+	for i := 0; i < 1000; i++ {
+		c.Get("k")
+	}
+	<-done
+}

--- a/go/examples/simple/main.go
+++ b/go/examples/simple/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/raja-aiml/sematic-cache/go/core"
+)
+
+func main() {
+	cache := core.NewCache()
+	cache.Set("hello", "world")
+	if val, ok := cache.Get("hello"); ok {
+		fmt.Println("cached:", val)
+	} else {
+		fmt.Println("not found")
+	}
+}

--- a/go/storage/pgstore.go
+++ b/go/storage/pgstore.go
@@ -64,3 +64,11 @@ func (s *PGStore) Get(prompt string) (string, bool, error) {
 	}
 	return ans, true, nil
 }
+
+// Close releases any database resources.
+func (s *PGStore) Close() error {
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
+}

--- a/go/storage/pgstore_test.go
+++ b/go/storage/pgstore_test.go
@@ -69,3 +69,21 @@ func TestPGStoreSetGet(t *testing.T) {
 		t.Fatalf("Get failed: %v %v %v", val, ok, err)
 	}
 }
+
+func TestPGStoreClose(t *testing.T) {
+	db := &fakeDB{}
+	oldExec := execFunc
+	oldQuery := queryRowFunc
+	execFunc = func(_ *sql.DB, q string, args ...interface{}) (sql.Result, error) {
+		return db.Exec(q, args...)
+	}
+	queryRowFunc = func(_ *sql.DB, q string, args ...interface{}) scanner {
+		return db.QueryRow(q, args...)
+	}
+	defer func() { execFunc = oldExec; queryRowFunc = oldQuery }()
+
+	store := &PGStore{}
+	if err := store.Close(); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- make Go cache concurrency-safe
- add Close method to PGStore
- demonstrate simple usage under `go/examples/simple`
- document Go example
- update tests

## Testing
- `go vet ./...`
- `go test ./...`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684b4988ff508325973b2fa3cc3b6dd5