### PR TITLE
Add doc reviewing Go feature parity

### DIFF
--- a/docs/go_feature_review.md
+++ b/docs/go_feature_review.md
@@ -1,0 +1,19 @@
+# Go Implementation Status
+
+This document compares the initial Go implementation with the existing Python codebase. It focuses on support for OpenAI, PostgreSQL, and `pgvector` as required in the migration plan.
+
+## Implemented
+
+- **Cache logic**: `go/core/cache.go` provides a concurrent in-memory cache with `Set` and `Get` methods similar to `gptcache.Cache` in Python.
+- **OpenAI client**: `go/openai/client.go` implements a minimal wrapper calling the completion endpoint.
+- **HTTP server**: `go/server/server.go` exposes `/set` and `/get` endpoints compatible with the Python server.
+- **PostgreSQL storage**: `go/storage/pgstore.go` stores prompts, embeddings and answers in a table created with the `VECTOR` column type.
+
+## Missing functionality
+
+- **Embedding similarity search** using `pgvector` operators (e.g. `<->`) is not implemented. The Go store currently retrieves rows only by prompt.
+- **Prepared statements and connection pooling** for PostgreSQL are not yet used.
+- **Automatic embedding extraction** like `gptcache.embedding` in Python is absent.
+- **Cache manager features** such as eviction policies and vector search integration are not ported.
+
+The Go modules therefore cover basic storage and retrieval but do not yet provide the full semantic caching workflow present in the Python version.


### PR DESCRIPTION
## Summary
- document the current Go feature status compared to the Python code

## Testing
- `go vet ./...`
- `go test ./...`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684b4ab623908325a1602063dff2353a