### PR TITLE
Fix import grouping in main server binary

### DIFF
--- a/go/cmd/server/main.go
+++ b/go/cmd/server/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"flag"
+
 	"github.com/raja-aiml/sematic-cache/go/core"
 	"github.com/raja-aiml/sematic-cache/go/server"
 )


### PR DESCRIPTION
## Summary
- ensure import groups have blank line between standard library and local packages in cmd/server/main.go

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684b4ee91a588325b54128900be1f021