### PR TITLE
Refactor OpenAI client to use official Go SDK

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -3,9 +3,10 @@ module github.com/raja-aiml/sematic-cache/go
 go 1.23.8
 
 require (
-	go.opentelemetry.io/otel v1.17.0
-	go.opentelemetry.io/otel/exporters/jaeger v1.17.0
-	go.opentelemetry.io/otel/sdk v1.17.0
+        go.opentelemetry.io/otel v1.17.0
+        go.opentelemetry.io/otel/exporters/jaeger v1.17.0
+        go.opentelemetry.io/otel/sdk v1.17.0
+        github.com/sashabaranov/go-openai v1.15.0
 )
 
 require (

--- a/go/openai/client.go
+++ b/go/openai/client.go
@@ -1,119 +1,72 @@
-// Package openai provides a minimal client wrapper for the OpenAI API.
+// Package openai provides a minimal client wrapper for the OpenAI API using the
+// official Go SDK.
 
 package openai
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
+
+	openai "github.com/sashabaranov/go-openai"
 )
 
-// Client wraps OpenAI API calls.
+// Client wraps the OpenAI SDK client.
 type Client struct {
-	APIKey     string
-	BaseURL    string
-	HTTPClient *http.Client
+	apiKey  string
+	BaseURL string
+	client  *openai.Client
 }
 
 // NewClient creates a new OpenAI client.
 func NewClient(apiKey string) *Client {
-	return &Client{
-		APIKey:     apiKey,
-		BaseURL:    "https://api.openai.com/v1",
-		HTTPClient: &http.Client{},
+	c := &Client{apiKey: apiKey, BaseURL: openai.DefaultConfig(apiKey).BaseURL}
+	c.configure()
+	return c
+}
+
+func (c *Client) configure() {
+	cfg := openai.DefaultConfig(c.apiKey)
+	if c.BaseURL != "" {
+		cfg.BaseURL = c.BaseURL
 	}
+	c.client = openai.NewClientWithConfig(cfg)
 }
 
-// CompletionRequest holds the request body for completions.
-type CompletionRequest struct {
-	Model  string `json:"model"`
-	Prompt string `json:"prompt"`
-}
-
-// CompletionResponse holds the response body for completions.
-type CompletionResponse struct {
-	Choices []struct {
-		Text string `json:"text"`
-	} `json:"choices"`
-}
-
-// EmbeddingRequest holds the request body for embeddings.
-type EmbeddingRequest struct {
-	Model string `json:"model"`
-	Input string `json:"input"`
-}
-
-// EmbeddingResponse holds the response body for embeddings.
-type EmbeddingResponse struct {
-	Data []struct {
-		Embedding []float32 `json:"embedding"`
-	} `json:"data"`
+// SetBaseURL updates the API base URL and reinitializes the SDK client. This is
+// mainly used in tests.
+func (c *Client) SetBaseURL(url string) {
+	c.BaseURL = url
+	c.configure()
 }
 
 // Complete calls OpenAI's completion API.
 func (c *Client) Complete(ctx context.Context, prompt string) (string, error) {
-	reqBody, err := json.Marshal(CompletionRequest{Model: "text-davinci-003", Prompt: prompt})
+	req := openai.CompletionRequest{
+		Model:  "text-davinci-003",
+		Prompt: prompt,
+	}
+	resp, err := c.client.CreateCompletion(ctx, req)
 	if err != nil {
 		return "", err
 	}
-	req, err := http.NewRequestWithContext(ctx, "POST", c.BaseURL+"/completions", bytes.NewBuffer(reqBody))
-	if err != nil {
-		return "", err
-	}
-	req.Header.Set("Authorization", "Bearer "+c.APIKey)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.HTTPClient.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("openai: unexpected status %s", resp.Status)
-	}
-
-	var res CompletionResponse
-	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
-		return "", err
-	}
-	if len(res.Choices) == 0 {
+	if len(resp.Choices) == 0 {
 		return "", fmt.Errorf("openai: no choices returned")
 	}
-	return res.Choices[0].Text, nil
+	return resp.Choices[0].Text, nil
 }
 
 // Embedding calls OpenAI's embedding API.
 func (c *Client) Embedding(ctx context.Context, text string) ([]float32, error) {
-	reqBody, err := json.Marshal(EmbeddingRequest{Model: "text-embedding-ada-002", Input: text})
+	req := openai.EmbeddingRequest{
+		Model: "text-embedding-ada-002",
+		Input: []string{text},
+	}
+	resp, err := c.client.CreateEmbeddings(ctx, req)
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequestWithContext(ctx, "POST", c.BaseURL+"/embeddings", bytes.NewBuffer(reqBody))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Authorization", "Bearer "+c.APIKey)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.HTTPClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("openai: unexpected status %s", resp.Status)
-	}
-
-	var res EmbeddingResponse
-	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
-		return nil, err
-	}
-	if len(res.Data) == 0 {
+	if len(resp.Data) == 0 {
 		return nil, fmt.Errorf("openai: no embedding returned")
 	}
-	return res.Data[0].Embedding, nil
+	return resp.Data[0].Embedding, nil
 }


### PR DESCRIPTION
## Summary
- replace custom HTTP calls with official `go-openai` SDK
- update tests to handle SDK requests
- add `go-openai` dependency

## Testing
- `go vet ./...` *(fails: could not download modules)*
- `go test ./...` *(fails: could not download modules)*

------
https://chatgpt.com/codex/tasks/task_e_684b9696881c8325b68ba95e4cae2f2f