### PR TITLE
Add flush, import and key config in Go

### DIFF
--- a/go/core/cache_test.go
+++ b/go/core/cache_test.go
@@ -28,3 +28,20 @@ func TestCacheGetByEmbedding(t *testing.T) {
 		t.Fatalf("expected a2, got %v %v", ans, ok)
 	}
 }
+
+func TestCacheFlushAndImport(t *testing.T) {
+	c := NewCache(3)
+	c.Set("p1", []float32{1, 0}, "a1")
+	c.Flush()
+	if _, ok := c.Get("p1"); ok {
+		t.Fatalf("expected empty cache")
+	}
+
+	prompts := []string{"p2", "p3"}
+	embeddings := [][]float32{{0, 1}, {1, 1}}
+	answers := []string{"a2", "a3"}
+	c.ImportData(prompts, embeddings, answers)
+	if val, ok := c.Get("p2"); !ok || val != "a2" {
+		t.Fatalf("import failed")
+	}
+}

--- a/go/openai/client.go
+++ b/go/openai/client.go
@@ -4,37 +4,41 @@
 package openai
 
 import (
-   "context"
-   "fmt"
+	"context"
+	"fmt"
 
-   openai "github.com/openai/openai-go"
-   "github.com/openai/openai-go/option"
-   "github.com/openai/openai-go/packages/param"
+	openai "github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+	"github.com/openai/openai-go/packages/param"
 )
 
 // Client wraps the OpenAI SDK client.
 // Client wraps the OpenAI SDK client.
 type Client struct {
-   apiKey  string
-   BaseURL string
-   client  openai.Client
+	apiKey     string
+	BaseURL    string
+	APIVersion string
+	client     openai.Client
 }
 
 // NewClient creates a new OpenAI client.
 // NewClient creates a new OpenAI client.
 func NewClient(apiKey string) *Client {
-   c := &Client{apiKey: apiKey}
-   c.configure()
-   return c
+	c := &Client{apiKey: apiKey}
+	c.configure()
+	return c
 }
 
 // configure initializes the underlying openai.Client with options.
 func (c *Client) configure() {
-   opts := []option.RequestOption{option.WithAPIKey(c.apiKey)}
-   if c.BaseURL != "" {
-       opts = append(opts, option.WithBaseURL(c.BaseURL))
-   }
-   c.client = openai.NewClient(opts...)
+	opts := []option.RequestOption{option.WithAPIKey(c.apiKey)}
+	if c.BaseURL != "" {
+		opts = append(opts, option.WithBaseURL(c.BaseURL))
+	}
+	if c.APIVersion != "" {
+		opts = append(opts, option.WithQuery("api-version", c.APIVersion))
+	}
+	c.client = openai.NewClient(opts...)
 }
 
 // SetBaseURL updates the API base URL and reinitializes the SDK client. This is
@@ -44,15 +48,29 @@ func (c *Client) SetBaseURL(url string) {
 	c.configure()
 }
 
+// SetAPIKey updates the API key and reinitializes the SDK client.
+func (c *Client) SetAPIKey(key string) {
+	c.apiKey = key
+	c.configure()
+}
+
+// ConfigureAzure sets Azure OpenAI specific parameters from environment.
+func (c *Client) ConfigureAzure(key, baseURL, version string) {
+	c.apiKey = key
+	c.BaseURL = baseURL
+	c.APIVersion = version
+	c.configure()
+}
+
 // Complete calls OpenAI's completion API.
 func (c *Client) Complete(ctx context.Context, prompt string) (string, error) {
-   params := openai.CompletionNewParams{
-       Model: "text-davinci-003",
-       Prompt: openai.CompletionNewParamsPromptUnion{
-           OfString: param.NewOpt(prompt),
-       },
-   }
-   resp, err := c.client.Completions.New(ctx, params)
+	params := openai.CompletionNewParams{
+		Model: "text-davinci-003",
+		Prompt: openai.CompletionNewParamsPromptUnion{
+			OfString: param.NewOpt(prompt),
+		},
+	}
+	resp, err := c.client.Completions.New(ctx, params)
 	if err != nil {
 		return "", err
 	}
@@ -64,23 +82,23 @@ func (c *Client) Complete(ctx context.Context, prompt string) (string, error) {
 
 // Embedding calls OpenAI's embedding API.
 func (c *Client) Embedding(ctx context.Context, text string) ([]float32, error) {
-   params := openai.EmbeddingNewParams{
-       Model: openai.EmbeddingModelTextEmbeddingAda002,
-       Input: openai.EmbeddingNewParamsInputUnion{
-           OfArrayOfStrings: []string{text},
-       },
-   }
-   resp, err := c.client.Embeddings.New(ctx, params)
+	params := openai.EmbeddingNewParams{
+		Model: openai.EmbeddingModelTextEmbeddingAda002,
+		Input: openai.EmbeddingNewParamsInputUnion{
+			OfArrayOfStrings: []string{text},
+		},
+	}
+	resp, err := c.client.Embeddings.New(ctx, params)
 	if err != nil {
 		return nil, err
 	}
-   if len(resp.Data) == 0 {
-       return nil, fmt.Errorf("openai: no embedding returned")
-   }
-   raw := resp.Data[0].Embedding
-   vec := make([]float32, len(raw))
-   for i, v := range raw {
-       vec[i] = float32(v)
-   }
-   return vec, nil
+	if len(resp.Data) == 0 {
+		return nil, fmt.Errorf("openai: no embedding returned")
+	}
+	raw := resp.Data[0].Embedding
+	vec := make([]float32, len(raw))
+	for i, v := range raw {
+		vec[i] = float32(v)
+	}
+	return vec, nil
 }

--- a/go/openai/client_test.go
+++ b/go/openai/client_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestComplete(t *testing.T) {
-   handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-       w.Header().Set("Content-Type", "application/json")
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		var req map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Fatalf("bad request: %v", err)
@@ -39,8 +39,8 @@ func TestComplete(t *testing.T) {
 }
 
 func TestEmbedding(t *testing.T) {
-   handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-       w.Header().Set("Content-Type", "application/json")
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		var req map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Fatalf("bad request: %v", err)
@@ -66,5 +66,20 @@ func TestEmbedding(t *testing.T) {
 	}
 	if len(got) != 2 || got[0] != 1 || got[1] != 2 {
 		t.Fatalf("unexpected embedding %v", got)
+	}
+}
+
+func TestClientConfig(t *testing.T) {
+	c := NewClient("k1")
+	if c.apiKey != "k1" {
+		t.Fatalf("expected k1")
+	}
+	c.SetAPIKey("k2")
+	if c.apiKey != "k2" {
+		t.Fatalf("expected k2")
+	}
+	c.ConfigureAzure("k3", "http://x", "2023-09-01")
+	if c.BaseURL != "http://x" || c.APIVersion != "2023-09-01" || c.apiKey != "k3" {
+		t.Fatalf("azure config not applied")
 	}
 }

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -26,6 +26,7 @@ func New(c *core.Cache) *Server {
 func (s *Server) routes() {
 	s.mux.HandleFunc("/get", s.handleGet)
 	s.mux.HandleFunc("/set", s.handleSet)
+	s.mux.HandleFunc("/flush", s.handleFlush)
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -54,6 +55,11 @@ func (s *Server) handleSet(w http.ResponseWriter, r *http.Request) {
 	}
 	s.Cache.Set(req.Prompt, nil, req.Answer)
 	w.WriteHeader(http.StatusCreated)
+}
+
+func (s *Server) handleFlush(w http.ResponseWriter, r *http.Request) {
+	s.Cache.Flush()
+	w.WriteHeader(http.StatusOK)
 }
 
 // Run starts the HTTP server.

--- a/go/server/server_test.go
+++ b/go/server/server_test.go
@@ -38,3 +38,20 @@ func TestServerSetGet(t *testing.T) {
 		t.Fatalf("expected a, got %s", data["answer"])
 	}
 }
+
+func TestServerFlush(t *testing.T) {
+	cache := core.NewCache(10)
+	srv := New(cache)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	body, _ := json.Marshal(map[string]string{"prompt": "p", "answer": "a"})
+	http.Post(ts.URL+"/set", "application/json", bytes.NewBuffer(body))
+	http.Post(ts.URL+"/flush", "application/json", nil)
+
+	body, _ = json.Marshal(map[string]string{"prompt": "p"})
+	resp, _ := http.Post(ts.URL+"/get", "application/json", bytes.NewBuffer(body))
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected not found after flush, got %v", resp.StatusCode)
+	}
+}

--- a/go/storage/pgstore.go
+++ b/go/storage/pgstore.go
@@ -149,6 +149,30 @@ func (s *PGStore) GetByEmbedding(embed []float32) (string, bool, error) {
 	return ans, true, nil
 }
 
+// Flush removes all cached rows.
+func (s *PGStore) Flush() error {
+	_, err := execFunc(s.db, `DELETE FROM cache`)
+	return err
+}
+
+// ImportData bulk loads prompts with their embeddings and answers.
+func (s *PGStore) ImportData(prompts []string, embeddings [][]float32, answers []string) error {
+	for i, p := range prompts {
+		var e []float32
+		if i < len(embeddings) {
+			e = embeddings[i]
+		}
+		var a string
+		if i < len(answers) {
+			a = answers[i]
+		}
+		if err := s.Set(p, e, a); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Close releases any database resources.
 func (s *PGStore) Close() error {
 	if s.setStmt != nil {

--- a/go/storage/pgstore_test.go
+++ b/go/storage/pgstore_test.go
@@ -66,6 +66,19 @@ func TestPGStoreSetGet(t *testing.T) {
 	}
 }
 
+func TestPGStoreImportFlush(t *testing.T) {
+	db := &fakeDB{}
+	store := &PGStore{setStmt: &fakeStmt{db}, getStmt: &fakeStmt{db}, similarStmt: &fakeStmt{db}}
+	prompts := []string{"p1", "p2"}
+	answers := []string{"a1", "a2"}
+	if err := store.ImportData(prompts, nil, answers); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if err := store.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+}
+
 func TestPGStoreClose(t *testing.T) {
 	store := &PGStore{setStmt: &fakeStmt{}, getStmt: &fakeStmt{}, similarStmt: &fakeStmt{}}
 	if err := store.Close(); err != nil {

--- a/gp/docs/diffrence.md
+++ b/gp/docs/diffrence.md
@@ -1,0 +1,27 @@
+# Python vs Go Implementation Differences
+
+This document lists features from the original Python code that are not yet present in the Go rewrite. Items are grouped by subsystem.
+
+## Core Cache Logic
+- **Initialization parameters**: Python `Cache.init` allows custom functions for enabling cache, embedding, pre/post processing and chaining multiple caches.
+- **API key helpers**: `set_openai_key` and `set_azure_openai_key` configure OpenAI credentials.
+- **Go status**: the Go `Cache` now supports `ImportData` and `Flush` but still lacks customizable init hooks.
+
+## Storage Layer
+- **Python DataManager**: pluggable layers handle in-memory, file based or vector store backends with eviction policies.
+- **PostgreSQL integration**: Python supports pgvector via managers; Go offers a basic `PGStore` with prepared statements and similarity search but lacks higher level DataManager abstractions.
+
+## OpenAI Integration
+- **Python adapter**: functions in `gptcache.adapter` intercept OpenAI requests, compute embeddings and cache responses transparently.
+- **Client utilities**: asynchronous `_put` and `_get` wrappers in `gptcache.client` for talking to the Python server.
+- **Go wrapper**: `openai.Client` exposes only `Complete` and `Embedding` methods and no automatic caching.
+
+## HTTP Server
+- **Python FastAPI server**: endpoints for `/put`, `/get`, `/flush`, `/cache_file` download and an OpenAI compatible `/v1/chat/completions` proxy with streaming.
+- **Go server**: now supports `/set`, `/get` and `/flush` but lacks the proxy and file download routes.
+
+## Examples and Documentation
+- **Python**: numerous example folders demonstrating adapters, embeddings, eviction, integration and session usage. README provides detailed setup and usage instructions.
+- **Go**: single `go/examples/simple` program illustrating basic cache operations. README section describes building and running the Go server but lacks advanced tutorials.
+
+These gaps highlight the ongoing migration work required for the Go implementation to reach feature parity with the Python project.


### PR DESCRIPTION
## Summary
- extend Go cache with `Flush` and `ImportData`
- allow OpenAI client API key updates and Azure config
- support `/flush` route in Go HTTP server
- implement flush and import in PostgreSQL storage
- update Go difference document

## Testing
- `go vet ./...` *(fails: proxy blocked)*
- `go test ./...` *(fails: proxy blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684b9be075908325889e6baeb311c2be