### PR TITLE
Add configurable caching options

### DIFF
--- a/go/core/cache.go
+++ b/go/core/cache.go
@@ -4,6 +4,7 @@ package core
 
 import (
 	"container/list"
+	"fmt"
 	"math"
 	"sync"
 )
@@ -21,23 +22,57 @@ type Cache struct {
 	entries  map[string]*list.Element
 	lru      *list.List
 	capacity int
+
+	cacheEnable func(string) bool
+	embedFunc   EmbeddingFunc
+	simFunc     func(a, b []float32) float64
+}
+
+// EmbeddingFunc converts a prompt into an embedding vector.
+// It may return an error if embedding fails.
+type EmbeddingFunc func(string) ([]float32, error)
+
+// Option configures a Cache.
+type Option func(*Cache)
+
+// WithEmbeddingFunc sets a function used to generate embeddings when calling
+// SetPrompt. If not provided, SetPrompt will return an error.
+func WithEmbeddingFunc(fn EmbeddingFunc) Option { return func(c *Cache) { c.embedFunc = fn } }
+
+// WithCacheEnable sets a function that determines whether a prompt should be
+// cached. If nil, all prompts are cached.
+func WithCacheEnable(fn func(string) bool) Option { return func(c *Cache) { c.cacheEnable = fn } }
+
+// WithSimilarityFunc overrides the vector similarity metric used by GetByEmbedding.
+// By default cosine similarity is used.
+func WithSimilarityFunc(fn func(a, b []float32) float64) Option {
+	return func(c *Cache) { c.simFunc = fn }
 }
 
 // NewCache creates a cache with the given capacity.
-func NewCache(capacity int) *Cache {
-   // capacity must be positive
-   if capacity <= 0 {
-       panic("core: capacity must be > 0")
-   }
-   return &Cache{
-       entries:  make(map[string]*list.Element),
-       lru:      list.New(),
-       capacity: capacity,
-   }
+func NewCache(capacity int, opts ...Option) *Cache {
+	// capacity must be positive
+	if capacity <= 0 {
+		panic("core: capacity must be > 0")
+	}
+	c := &Cache{
+		entries:     make(map[string]*list.Element),
+		lru:         list.New(),
+		capacity:    capacity,
+		cacheEnable: func(string) bool { return true },
+		simFunc:     cosine,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
 // Set stores an answer and embedding for the given prompt.
 func (c *Cache) Set(prompt string, embedding []float32, answer string) {
+	if c.cacheEnable != nil && !c.cacheEnable(prompt) {
+		return
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -49,8 +84,23 @@ func (c *Cache) Set(prompt string, embedding []float32, answer string) {
 		return
 	}
 
-   ent := &entry{prompt: prompt, embedding: embedding, answer: answer}
-   c.insertEntry(ent)
+	ent := &entry{prompt: prompt, embedding: embedding, answer: answer}
+	c.insertEntry(ent)
+}
+
+// SetPrompt generates an embedding for the prompt using the configured
+// EmbeddingFunc and stores the answer in the cache.
+// It returns an error if no EmbeddingFunc is configured or embedding fails.
+func (c *Cache) SetPrompt(prompt, answer string) error {
+	if c.embedFunc == nil {
+		return fmt.Errorf("no EmbeddingFunc configured")
+	}
+	emb, err := c.embedFunc(prompt)
+	if err != nil {
+		return err
+	}
+	c.Set(prompt, emb, answer)
+	return nil
 }
 
 // Get returns the cached answer for a prompt and whether it was found.
@@ -78,7 +128,7 @@ func (c *Cache) GetByEmbedding(embed []float32) (string, bool) {
 		if len(ent.embedding) != len(embed) || len(embed) == 0 {
 			continue
 		}
-		sim := cosine(ent.embedding, embed)
+		sim := c.simFunc(ent.embedding, embed)
 		if !initBest || sim > bestSim {
 			best = e
 			bestSim = sim
@@ -102,15 +152,15 @@ func (c *Cache) Flush() {
 
 // insertEntry adds a new entry (assumes c.mu is held), evicting the oldest if over capacity.
 func (c *Cache) insertEntry(ent *entry) {
-   el := c.lru.PushFront(ent)
-   c.entries[ent.prompt] = el
-   if c.lru.Len() > c.capacity {
-       tail := c.lru.Back()
-       if tail != nil {
-           c.lru.Remove(tail)
-           delete(c.entries, tail.Value.(*entry).prompt)
-       }
-   }
+	el := c.lru.PushFront(ent)
+	c.entries[ent.prompt] = el
+	if c.lru.Len() > c.capacity {
+		tail := c.lru.Back()
+		if tail != nil {
+			c.lru.Remove(tail)
+			delete(c.entries, tail.Value.(*entry).prompt)
+		}
+	}
 }
 
 // ImportData loads multiple prompt/embedding/answer triples into the cache.

--- a/go/core/cache_test.go
+++ b/go/core/cache_test.go
@@ -1,6 +1,9 @@
 package core
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestCacheSetGet(t *testing.T) {
 	c := NewCache(2)
@@ -43,5 +46,21 @@ func TestCacheFlushAndImport(t *testing.T) {
 	c.ImportData(prompts, embeddings, answers)
 	if val, ok := c.Get("p2"); !ok || val != "a2" {
 		t.Fatalf("import failed")
+	}
+}
+
+func TestCacheSetPrompt(t *testing.T) {
+	embFn := func(p string) ([]float32, error) {
+		if p == "p" {
+			return []float32{1, 0}, nil
+		}
+		return nil, fmt.Errorf("unknown prompt")
+	}
+	c := NewCache(2, WithEmbeddingFunc(embFn))
+	if err := c.SetPrompt("p", "a"); err != nil {
+		t.Fatalf("SetPrompt error: %v", err)
+	}
+	if ans, ok := c.Get("p"); !ok || ans != "a" {
+		t.Fatalf("expected cached answer, got %v %v", ans, ok)
 	}
 }

--- a/gp/docs/diffrence.md
+++ b/gp/docs/diffrence.md
@@ -5,7 +5,7 @@ This document lists features from the original Python code that are not yet pres
 ## Core Cache Logic
 - **Initialization parameters**: Python `Cache.init` allows custom functions for enabling cache, embedding, pre/post processing and chaining multiple caches.
 - **API key helpers**: `set_openai_key` and `set_azure_openai_key` configure OpenAI credentials.
-- **Go status**: the Go `Cache` now supports `ImportData` and `Flush` but still lacks customizable init hooks.
+- **Go status**: the Go `Cache` now supports `ImportData`, `Flush` and basic customization through `WithEmbeddingFunc`, `WithCacheEnable` and `WithSimilarityFunc` options. Advanced pre/post hooks are not yet available.
 
 ## Storage Layer
 - **Python DataManager**: pluggable layers handle in-memory, file based or vector store backends with eviction policies.


### PR DESCRIPTION
## Summary
- implement option-based configuration for Go cache
- expose SetPrompt helper using embedding function
- extend cache unit tests for new features
- document new options in migration diff guide

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684ba89579888325ac07fcb37b594bdf