### PR TITLE
docs: expand example instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,16 @@ go run cmd/server/main.go -config config.yml
 go run cmd/server/main.go -address :8080
 ```
 
+### Docker Compose
+To run the server with PostgreSQL and Redis via Docker:
+```bash
+docker compose -f deploy/docker/docker-compose.yml up --build
+```
+Stop the containers with:
+```bash
+docker compose -f deploy/docker/docker-compose.yml down
+```
+
 ### API Endpoints
 
 #### Store a Cache Entry
@@ -322,10 +332,10 @@ go test ./server
 ```
 
 ## Examples
-
-Check the `examples/` directory for:
-- **Simple usage**: Basic caching operations
-- **Advanced usage**: ANN index integration, custom similarity functions
+Example programs live under `examples/`. Each subdirectory has its own README.
+- **simple/**: in-memory caching demo
+- **advanced/**: ANN index and custom similarity
+- **docker/**: server setup with Docker Compose
 
 ## Contributing
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,33 @@
+# Example Programs
+
+This folder contains small programs and setup instructions that help you get started with the semantic cache.
+
+## Prerequisites
+- Go 1.23 or newer
+- Docker 20.10+ with Compose V2 (for the Docker example)
+
+## Usage
+Each subdirectory includes a README with details:
+
+### simple
+Minimal in-memory cache example.
+```bash
+go run ./examples/simple
+```
+
+### advanced
+Demonstrates inner-product similarity and a naive ANN index.
+```bash
+go run ./examples/advanced
+```
+
+### docker
+Quick start for running the server with PostgreSQL and Redis.
+```bash
+docker compose -f deploy/docker/docker-compose.yml up --build
+```
+Stop the containers with:
+```bash
+docker compose -f deploy/docker/docker-compose.yml down
+```
+See `docker/README.md` for more information.

--- a/examples/advanced/README.md
+++ b/examples/advanced/README.md
@@ -1,0 +1,11 @@
+# Advanced Example
+
+This example uses a naive in-memory approximate nearest neighbor index and inner-product similarity to demonstrate more sophisticated queries.
+
+Run it from the repository root:
+
+```bash
+go run ./examples/advanced
+```
+
+No external services or configuration are required.

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -1,0 +1,20 @@
+# Docker Quick Start
+
+This example shows how to start the caching server together with Postgres and Redis using the Docker Compose setup provided under `deploy/docker`.
+
+## Prerequisites
+- Docker 20.10 or newer
+- Docker Compose V2 (included in the `docker` CLI)
+
+## Usage
+1. Copy your OpenAI API key into the `OPENAI_API_KEY` environment variable.
+2. From the project root run:
+```bash
+docker compose -f deploy/docker/docker-compose.yml up --build
+```
+3. The server listens on `localhost:8080`.
+4. Stop and remove the containers with:
+```bash
+docker compose -f deploy/docker/docker-compose.yml down
+```
+The compose file builds the server image from the repository and starts both databases with default credentials. It is shared with the main deployment configuration to avoid duplication.

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -1,0 +1,11 @@
+# Simple Example
+
+This program demonstrates basic in-memory caching. It stores a key and retrieves it from the cache.
+
+Run it from the repository root:
+
+```bash
+go run ./examples/simple
+```
+
+No additional setup is required.


### PR DESCRIPTION
## Summary
Add README files for each example and expand the main README with Docker compose instructions.

## Changes Made
- Updated `README.md` with Docker compose steps and revised examples section
- Expanded `examples/README.md` with detailed usage instructions
- Added `examples/simple/README.md`
- Added `examples/advanced/README.md`

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684f3f6fc0708325ae18a61dd5e6f5cb