### PR TITLE
deploy: add CLI for local build and deploy

### DIFF
--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -14,28 +14,29 @@ This directory contains Kubernetes manifests and helper scripts to deploy the Se
 - `postgres.yaml`: PVC, Deployment, and Service for PostgreSQL.
 - `redis.yaml`: Deployment and Service for Redis.
 - `sematic-cache.yaml`: Deployment and Service for the Sematic Cache API.
-- `cluster.sh`: Helper script to manage the k3d cluster and deploy resources.
+- `registry.yaml`: Deployment and Service for a local Docker registry.
+- `cluster.sh`: Manage the k3d cluster (create, delete, logs).
+- `dev.sh`: CLI to build the image, push to the local registry, and deploy.
 
 ## Usage
 
-1. Make `cluster.sh` executable if needed:
+1. Make the scripts executable if needed:
 
    ```bash
-   chmod +x cluster.sh
+   chmod +x cluster.sh dev.sh
    ```
 
-2. Start the cluster and deploy all components:
+2. Build the image and deploy everything:
 
    ```bash
-   ./cluster.sh up
+   ./dev.sh deploy
    ```
 
    This will:
+   - Start a local Docker registry `sematic-registry` on port `5000`
+   - Build the Docker image `sematic-cache:latest` and push it to the registry
    - Create a k3d cluster named `sematic-cache`
-   - Build the local Docker image `sematic-cache:latest` (using `deploy/docker/Dockerfile`) and import it into the cluster
-   - Expose port `8080` on your localhost to the Sematic Cache service
-   - Apply all Kubernetes manifests
-   - Wait for deployments to be ready
+   - Apply all Kubernetes manifests and wait for deployments
 
 3. View the status of the cluster:
 
@@ -55,15 +56,16 @@ This directory contains Kubernetes manifests and helper scripts to deploy the Se
    ./cluster.sh logs <pod-name> --follow
    ```
 
-5. Tear down the cluster:
+5. Tear down the cluster and registry:
 
    ```bash
-   ./cluster.sh down
+   ./dev.sh down
    ```
+   This command removes the k3d cluster and stops the `sematic-registry` container.
 
 ## Exposing Application
 
-After running `./cluster.sh up`, the Sematic Cache API will be accessible at:
+After running `./dev.sh deploy`, the Sematic Cache API will be accessible at:
 
 ```
 http://localhost:8080
@@ -71,8 +73,8 @@ http://localhost:8080
 
 ## Cleanup
 
-To remove the cluster and all resources:
+To remove the cluster, registry, and all resources:
 
 ```bash
-./cluster.sh down
+./dev.sh down
 ```

--- a/deploy/k8s/cluster.sh
+++ b/deploy/k8s/cluster.sh
@@ -9,16 +9,13 @@ KUBE_CONTEXT="k3d-${CLUSTER_NAME}"
 
 # Directory containing Kubernetes manifests
 MANIFEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Repository root (for building Docker image)
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$MANIFEST_DIR/../..")"
-DOCKERFILE="$REPO_ROOT/deploy/docker/Dockerfile"
 
 usage() {
     cat <<EOM
 Usage: $(basename "$0") <command> [args]
 
 Commands:
-  up                    Create k3d cluster and deploy Kubernetes resources
+  up                    Create k3d cluster and apply manifests
   down                  Delete k3d cluster
   ps                    List k3d clusters and Kubernetes resources
   logs [POD] [--follow] Show logs for a pod (default: all pods). Use --follow to tail logs.
@@ -32,10 +29,6 @@ cmd_up() {
     k3d cluster create "$CLUSTER_NAME" --agents 0 --port "8080:8080@loadbalancer" --kubeconfig-switch-context
     echo "Switching kubectl context to '$KUBE_CONTEXT'..."
     kubectl config use-context "$KUBE_CONTEXT"
-    echo "Building local server image 'sematic-cache:latest'..."
-    docker build -t sematic-cache:latest -f "$DOCKERFILE" "$REPO_ROOT"
-    echo "Importing 'sematic-cache:latest' into k3d cluster '$CLUSTER_NAME'..."
-    k3d image import sematic-cache:latest -c "$CLUSTER_NAME"
     echo "Waiting for Kubernetes nodes to be ready..."
     # Wait for the k3d control-plane node (named <context>-server-0)
     kubectl --context "$KUBE_CONTEXT" wait --for=condition=Ready node/"${KUBE_CONTEXT}-server-0" --timeout=60s

--- a/deploy/k8s/dev.sh
+++ b/deploy/k8s/dev.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+set -e
+
+REGISTRY_NAME="sematic-registry"
+IMAGE_NAME="sematic-cache:latest"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+CLUSTER_SCRIPT="$(cd "$(dirname "$0")" && pwd)/cluster.sh"
+
+usage() {
+    cat <<EOM
+Usage: $(basename "$0") <command>
+
+Commands:
+  build    Build the Docker image and push to local registry
+  deploy   Build, push, and deploy to k3d cluster
+  down     Tear down cluster and stop registry
+  help     Show this help message
+EOM
+}
+
+ensure_registry() {
+    if ! docker ps --format '{{.Names}}' | grep -q "^${REGISTRY_NAME}$"; then
+        echo "Starting local Docker registry '${REGISTRY_NAME}'..."
+        docker run -d -p 5000:5000 --name "$REGISTRY_NAME" registry:2
+    else
+        echo "Local Docker registry '${REGISTRY_NAME}' already running."
+    fi
+}
+
+cleanup_registry() {
+    if docker ps -a --format '{{.Names}}' | grep -q "^${REGISTRY_NAME}$"; then
+        echo "Deleting local Docker registry '${REGISTRY_NAME}'..."
+        docker rm -f "$REGISTRY_NAME" >/dev/null
+    fi
+}
+
+build_image() {
+    docker build -t "$IMAGE_NAME" -f "$REPO_ROOT/deploy/docker/Dockerfile" "$REPO_ROOT"
+}
+
+push_image() {
+    ensure_registry
+    docker tag "$IMAGE_NAME" "localhost:5000/$IMAGE_NAME"
+    docker push "localhost:5000/$IMAGE_NAME"
+}
+
+cmd_build() {
+    build_image
+    push_image
+}
+
+cmd_deploy() {
+    cmd_build
+    "$CLUSTER_SCRIPT" up
+}
+
+cmd_down() {
+    "$CLUSTER_SCRIPT" down
+    cleanup_registry
+}
+
+if [ $# -lt 1 ]; then
+    usage
+    exit 1
+fi
+
+case "$1" in
+    build)
+        cmd_build
+        ;;
+    deploy)
+        cmd_deploy
+        ;;
+    down)
+        cmd_down
+        ;;
+    help|*)
+        usage
+        ;;
+esac

--- a/deploy/k8s/registry.yaml
+++ b/deploy/k8s/registry.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: registry
+  template:
+    metadata:
+      labels:
+        app: registry
+    spec:
+      containers:
+        - name: registry
+          image: registry:2
+          ports:
+            - containerPort: 5000
+          volumeMounts:
+            - name: registry-storage
+              mountPath: /var/lib/registry
+      volumes:
+        - name: registry-storage
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry
+spec:
+  selector:
+    app: registry
+  ports:
+    - port: 5000
+      targetPort: 5000
+  type: ClusterIP


### PR DESCRIPTION
## Summary
Introduce `dev.sh` script for building the server image and deploying to a k3d cluster using a local registry. `cluster.sh` is simplified to manage only cluster lifecycle and manifest application.

## Changes Made
- Added `deploy/k8s/dev.sh` CLI for build/deploy/teardown.
- Refactored `deploy/k8s/cluster.sh` to remove registry and build logic.
- Updated `deploy/k8s/README.md` with new workflow.

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684f448fa43c83258d4e77451c6f5400