### PR TITLE
Refactor k8s deployment scripts

### DIFF
--- a/deploy/k8s/cluster.sh
+++ b/deploy/k8s/cluster.sh
@@ -32,10 +32,14 @@ cmd_up() {
     echo "Waiting for Kubernetes nodes to be ready..."
     # Wait for the k3d control-plane node (named <context>-server-0)
     kubectl --context "$KUBE_CONTEXT" wait --for=condition=Ready node/"${KUBE_CONTEXT}-server-0" --timeout=60s
-    echo "Applying Kubernetes manifests..."
-    kubectl --context "$KUBE_CONTEXT" apply -f "$MANIFEST_DIR"
+    echo "Applying base manifests..."
+    kubectl --context "$KUBE_CONTEXT" apply -f "$MANIFEST_DIR/pg-init-configmap.yaml"
+    kubectl --context "$KUBE_CONTEXT" apply -f "$MANIFEST_DIR/postgres.yaml"
+    kubectl --context "$KUBE_CONTEXT" apply -f "$MANIFEST_DIR/registry.yaml"
+    kubectl --context "$KUBE_CONTEXT" apply -f "$MANIFEST_DIR/redis.yaml"
     echo "Waiting for deployments to be ready..."
     kubectl --context "$KUBE_CONTEXT" rollout status deployment/postgres --timeout=120s
+    kubectl --context "$KUBE_CONTEXT" rollout status deployment/registry --timeout=120s
     kubectl --context "$KUBE_CONTEXT" rollout status deployment/redis --timeout=120s
 }
 

--- a/deploy/k8s/dev.sh
+++ b/deploy/k8s/dev.sh
@@ -6,6 +6,9 @@ REGISTRY_NAME="sematic-registry"
 IMAGE_NAME="sematic-cache:latest"
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 CLUSTER_SCRIPT="$(cd "$(dirname "$0")" && pwd)/cluster.sh"
+CLUSTER_NAME="sematic-cache"
+KUBE_CONTEXT="k3d-${CLUSTER_NAME}"
+APP_MANIFEST="$REPO_ROOT/deploy/k8s/sematic-cache.yaml"
 
 usage() {
     cat <<EOM
@@ -13,7 +16,7 @@ Usage: $(basename "$0") <command>
 
 Commands:
   build    Build the Docker image and push to local registry
-  deploy   Build, push, and deploy to k3d cluster
+  deploy   Build image, create cluster, and deploy application
   down     Tear down cluster and stop registry
   help     Show this help message
 EOM
@@ -45,6 +48,11 @@ push_image() {
     docker push "localhost:5000/$IMAGE_NAME"
 }
 
+deploy_app() {
+    kubectl --context "$KUBE_CONTEXT" apply -f "$APP_MANIFEST"
+    kubectl --context "$KUBE_CONTEXT" rollout status deployment/sematic-cache --timeout=120s
+}
+
 cmd_build() {
     build_image
     push_image
@@ -53,6 +61,7 @@ cmd_build() {
 cmd_deploy() {
     cmd_build
     "$CLUSTER_SCRIPT" up
+    deploy_app
 }
 
 cmd_down() {


### PR DESCRIPTION
## Summary
Split dependency installation and application deployment.

## Changes Made
- `deploy/k8s/cluster.sh` now installs only Postgres, registry and Redis
- `deploy/k8s/dev.sh` builds the image and deploys the application manifest

## Testing
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `gofmt -w .`


------
https://chatgpt.com/codex/tasks/task_e_684f4c2a6d08832593cb68e1ac746c3e