### PR TITLE
deploy: handle missing docker in debug script

### DIFF
--- a/deploy/k8s/debug.sh
+++ b/deploy/k8s/debug.sh
@@ -822,7 +822,7 @@ function analyze_docker_image_integrity() {
     
     if ! command -v docker >/dev/null 2>&1; then
         echo "❌ Docker not available for image analysis"
-        return 1
+        return 0
     fi
     
     if docker image inspect "$image" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
Fix `deploy/k8s/debug.sh` so the `debug full` command no longer aborts when
Docker is unavailable.

## Changes Made
- return success when Docker is not installed in
  `analyze_docker_image_integrity`

## Testing
- `gofmt -w $(git ls-files '*.go')`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684fa628f9f08325be53dfca4d99ba34