### PR TITLE
deploy: fix ingress path rewrite

### DIFF
--- a/deploy/k8s/app/sematic-cache.yaml
+++ b/deploy/k8s/app/sematic-cache.yaml
@@ -64,14 +64,15 @@ kind: Ingress
 metadata:
   name: sematic-cache-ingress
   annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/use-regex: "true"
 spec:
   ingressClassName: nginx
   rules:
     - host: sematic.127.0.0.1.nip.io
       http:
         paths:
-          - path: /
+          - path: /(.*)
             pathType: Prefix
             backend:
               service:


### PR DESCRIPTION
## Summary
Fix ingress configuration so API paths are preserved.

## Changes Made
- update ingress annotations and path regex in `deploy/k8s/app/sematic-cache.yaml`

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684fb19191608325ba5bccae961534a3