### PR TITLE
core: return error for invalid cache setup

### DIFF
--- a/core/cache.go
+++ b/core/cache.go
@@ -352,14 +352,12 @@ func WithTTL(d time.Duration) Option {
 
 // WithEvictionPolicy sets the in-memory eviction strategy. Valid values are
 // "LRU", "FIFO", "LFU", and "RR" (random replacement).
-func WithEvictionPolicy(policy string) Option {
-	return func(c *Cache) {
-		switch policy {
-		case PolicyLRU, PolicyFIFO, PolicyLFU, PolicyRR:
-			c.evictionPolicy = policy
-		default:
-			panic(fmt.Sprintf("core: unknown eviction policy %q", policy))
-		}
+func WithEvictionPolicy(policy string) (Option, error) {
+	switch policy {
+	case PolicyLRU, PolicyFIFO, PolicyLFU, PolicyRR:
+		return func(c *Cache) { c.evictionPolicy = policy }, nil
+	default:
+		return nil, fmt.Errorf("core: unknown eviction policy %q", policy)
 	}
 }
 
@@ -416,10 +414,10 @@ func WithEvaluationFunc(fn func([]QueryResult) []QueryResult) Option {
 }
 
 // NewCache creates a cache with the given capacity.
-func NewCache(capacity int, opts ...Option) *Cache {
+func NewCache(capacity int, opts ...Option) (*Cache, error) {
 	// capacity must be positive
 	if capacity <= 0 {
-		panic("core: capacity must be > 0")
+		return nil, fmt.Errorf("core: capacity must be > 0")
 	}
 	c := &Cache{
 		entries:        make(map[string]*list.Element),
@@ -433,7 +431,7 @@ func NewCache(capacity int, opts ...Option) *Cache {
 	for _, opt := range opts {
 		opt(c)
 	}
-	return c
+	return c, nil
 }
 
 // Set stores an answer and embedding for the given prompt, without model metadata.

--- a/core/cache_eviction_test.go
+++ b/core/cache_eviction_test.go
@@ -7,7 +7,14 @@ import (
 
 // TestLRUPolicy ensures that LRU eviction removes the least-recently-used item.
 func TestLRUPolicy(t *testing.T) {
-	cache := NewCache(2, WithEvictionPolicy(PolicyLRU))
+	opt, err := WithEvictionPolicy(PolicyLRU)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cache, err := NewCache(2, opt)
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
 	cache.Set("a", []float32{1}, "A")
 	cache.Set("b", []float32{2}, "B")
 	// Access "a" to make it most-recent
@@ -30,7 +37,14 @@ func TestLRUPolicy(t *testing.T) {
 
 // TestFIFOPolicy ensures that FIFO eviction removes the entry inserted earliest.
 func TestFIFOPolicy(t *testing.T) {
-	cache := NewCache(2, WithEvictionPolicy(PolicyFIFO))
+	opt, err := WithEvictionPolicy(PolicyFIFO)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cache, err := NewCache(2, opt)
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
 	cache.Set("a", []float32{1}, "A")
 	cache.Set("b", []float32{2}, "B")
 	// Access "a" should not affect FIFO order
@@ -52,7 +66,14 @@ func TestFIFOPolicy(t *testing.T) {
 
 // TestLFUPolicy ensures that LFU eviction removes the least-frequently-used item.
 func TestLFUPolicy(t *testing.T) {
-	cache := NewCache(2, WithEvictionPolicy(PolicyLFU))
+	opt, err := WithEvictionPolicy(PolicyLFU)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cache, err := NewCache(2, opt)
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
 	cache.Set("a", []float32{1}, "A")
 	cache.Set("b", []float32{2}, "B")
 	// Access frequencies: a:2 (1 initial +1), b:1
@@ -76,7 +97,14 @@ func TestLFUPolicy(t *testing.T) {
 func TestRRPolicy(t *testing.T) {
 	// Seed for reproducibility within this test run
 	rand.Seed(42)
-	cache := NewCache(2, WithEvictionPolicy(PolicyRR))
+	opt, err := WithEvictionPolicy(PolicyRR)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cache, err := NewCache(2, opt)
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
 	cache.Set("a", []float32{1}, "A")
 	cache.Set("b", []float32{2}, "B")
 	// Insert "c", should evict either 'a' or 'b'

--- a/core/cache_reduction_test.go
+++ b/core/cache_reduction_test.go
@@ -34,11 +34,14 @@ func TestCache_WithDimensionReduction(t *testing.T) {
 	}
 
 	// Create cache with dimension reduction
-	cache := NewCache(100,
+	cache, err := NewCache(100,
 		WithEmbeddingFunc(embedFunc),
 		WithDimensionReduction(reducer),
 		WithMinSimilarity(0.7),
 	)
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
 
 	// Test that ensureDualEmbeddings is set
 	if !cache.ensureDualEmbeddings {
@@ -126,11 +129,14 @@ func TestCache_HybridSearch(t *testing.T) {
 	}
 
 	// Create cache
-	cache := NewCache(100,
+	cache, err := NewCache(100,
 		WithEmbeddingFunc(embedFunc),
 		WithDimensionReduction(reducer),
 		WithMinSimilarity(0.5),
 	)
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
 
 	// Add entries
 	entries := []struct {
@@ -199,9 +205,12 @@ func TestCache_EnsureReducedEmbeddings(t *testing.T) {
 	}
 
 	// Create cache without reducer initially
-	cache := NewCache(50,
+	cache, err := NewCache(50,
 		WithEmbeddingFunc(embedFunc),
 	)
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
 
 	// Add entries
 	for i := 0; i < 15; i++ {
@@ -220,7 +229,7 @@ func TestCache_EnsureReducedEmbeddings(t *testing.T) {
 
 	// Try to ensure reduced embeddings - should auto-train
 	ctx := context.Background()
-	err := cache.EnsureReducedEmbeddings(ctx)
+	err = cache.EnsureReducedEmbeddings(ctx)
 	if err != nil {
 		t.Fatalf("EnsureReducedEmbeddings failed: %v", err)
 	}
@@ -248,10 +257,13 @@ func TestCache_DimensionReductionMetrics(t *testing.T) {
 
 	reducer, _ := reduction.NewDimensionReducer(config)
 
-	cache := NewCache(100,
+	cache, err := NewCache(100,
 		WithEmbeddingFunc(embedFunc),
 		WithDimensionReduction(reducer),
 	)
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
 
 	// Add entries and train
 	for i := 0; i < 20; i++ {
@@ -295,11 +307,14 @@ func TestCache_RegularSearchFallback(t *testing.T) {
 
 	reducer, _ := reduction.NewDimensionReducer(config)
 
-	cache := NewCache(50,
+	cache, err := NewCache(50,
 		WithEmbeddingFunc(embedFunc),
 		WithDimensionReduction(reducer),
 		WithMinSimilarity(0.5),
 	)
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
 
 	// Add entries
 	cache.SetPrompt("Short", "Short answer")

--- a/core/cache_test.go
+++ b/core/cache_test.go
@@ -7,7 +7,10 @@ import (
 )
 
 func TestCacheSetGet(t *testing.T) {
-	c := NewCache(2)
+	c, err := NewCache(2)
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
 	c.Set("p1", []float32{1, 0}, "a1")
 	c.Set("p2", []float32{0, 1}, "a2")
 
@@ -25,7 +28,10 @@ func TestCacheSetGet(t *testing.T) {
 // Test entry expiration via TTL.
 func TestTTLExpiration(t *testing.T) {
 	// TTL of 50ms
-	c := NewCache(2, WithTTL(50*time.Millisecond))
+	c, err := NewCache(2, WithTTL(50*time.Millisecond))
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
 	c.Set("p1", []float32{1}, "a1")
 	// immediately retrievable
 	if v, ok := c.Get("p1"); !ok || v != "a1" {
@@ -40,7 +46,10 @@ func TestTTLExpiration(t *testing.T) {
 
 // Test cache metrics: hits, misses, hit rate.
 func TestStats(t *testing.T) {
-	c := NewCache(2)
+	c, err := NewCache(2)
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
 	// misses
 	c.Get("x")
 	// hits
@@ -57,7 +66,10 @@ func TestStats(t *testing.T) {
 
 // Test batch set and get operations.
 func TestBatchSetGet(t *testing.T) {
-	c := NewCache(5)
+	c, err := NewCache(5)
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
 	prompts := []string{"a", "b", "c"}
 	embeddings := [][]float32{{1}, {2}, {3}}
 	answers := []string{"A", "B", "C"}
@@ -72,7 +84,10 @@ func TestBatchSetGet(t *testing.T) {
 }
 
 func TestCacheGetByEmbedding(t *testing.T) {
-	c := NewCache(2)
+	c, err := NewCache(2)
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
 	c.Set("p1", []float32{1, 0}, "a1")
 	c.Set("p2", []float32{0, 1}, "a2")
 
@@ -83,7 +98,10 @@ func TestCacheGetByEmbedding(t *testing.T) {
 }
 
 func TestCacheFlushAndImport(t *testing.T) {
-	c := NewCache(3)
+	c, err := NewCache(3)
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
 	c.Set("p1", []float32{1, 0}, "a1")
 	c.Flush()
 	if _, ok := c.Get("p1"); ok {
@@ -106,7 +124,10 @@ func TestCacheSetPrompt(t *testing.T) {
 		}
 		return nil, fmt.Errorf("unknown prompt")
 	}
-	c := NewCache(2, WithEmbeddingFunc(embFn))
+	c, err := NewCache(2, WithEmbeddingFunc(embFn))
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
 	if err := c.SetPrompt("p", "a"); err != nil {
 		t.Fatalf("SetPrompt error: %v", err)
 	}
@@ -118,7 +139,10 @@ func TestCacheSetPrompt(t *testing.T) {
 // Test that GetByEmbedding respects the min similarity threshold.
 func TestGetByEmbeddingThreshold(t *testing.T) {
 	// insert two orthogonal unit vectors
-	c := NewCache(2, WithMinSimilarity(0.8))
+	c, err := NewCache(2, WithMinSimilarity(0.8))
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
 	c.Set("p1", []float32{1, 0}, "a1")
 	c.Set("p2", []float32{0, 1}, "a2")
 	// query exactly matches p1 -> sim=1
@@ -133,7 +157,10 @@ func TestGetByEmbeddingThreshold(t *testing.T) {
 
 // Test top-K similarity search.
 func TestGetTopKByEmbedding(t *testing.T) {
-	c := NewCache(3)
+	c, err := NewCache(3)
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
 	c.Set("p1", []float32{1, 0}, "a1")
 	c.Set("p2", []float32{0, 1}, "a2")
 	c.Set("p3", []float32{1, 1}, "a3")

--- a/examples/advanced/main.go
+++ b/examples/advanced/main.go
@@ -58,11 +58,14 @@ func (n *NaiveANNIndex) Search(query []float32, k int) ([]string, error) {
 func main() {
 	// Prepare a naive ANN index and a cache using inner-product similarity.
 	ann := NewNaiveANNIndex()
-	cache := core.NewCache(10,
+	cache, err := core.NewCache(10,
 		core.WithInnerProduct(),
 		core.WithANNIndex(ann),
 		core.WithMinSimilarity(0.0),
 	)
+	if err != nil {
+		panic(err)
+	}
 
 	// Sample data: prompt -> (vector, answer)
 	data := map[string]struct {
@@ -97,11 +100,14 @@ func main() {
 		}
 		return sum / float64(len(sims))
 	}
-	cache2 := core.NewCache(10,
+	cache2, err := core.NewCache(10,
 		core.WithInnerProduct(),
 		core.WithANNIndex(ann),
 		core.WithAdaptiveThreshold(meanThreshold),
 	)
+	if err != nil {
+		panic(err)
+	}
 	for prompt, d := range data {
 		cache2.Set(prompt, d.vec, d.ans)
 	}

--- a/examples/dimension_reduction/main.go
+++ b/examples/dimension_reduction/main.go
@@ -29,8 +29,8 @@ func main() {
 			OutputDimensions: 384,  // Reduce from 1536 to 384 dimensions
 			VarianceRetained: 0.95, // Retain 95% variance
 		},
-		Type:               reduction.PCAReducerType,  // Use PCA algorithm
-		EnableOptimization: true,                      // Use optimized Gonum implementation
+		Type:               reduction.PCAReducerType, // Use PCA algorithm
+		EnableOptimization: true,                     // Use optimized Gonum implementation
 	}
 
 	// Create dimension reducer using factory
@@ -101,12 +101,15 @@ func main() {
 	}
 
 	// Step 3: Create cache with dimension reduction and A/B testing
-	cache := core.NewCache(10000,
+	cache, err := core.NewCache(10000,
 		core.WithMinSimilarity(0.8),
 		core.WithEmbeddingFunc(embedFunc),
 		core.WithDimensionReduction(reducer),
 		core.WithABTestManager(abTestManager),
 	)
+	if err != nil {
+		log.Fatalf("failed to create cache: %v", err)
+	}
 
 	// Step 4: Populate cache with sample data
 	fmt.Println("Populating cache with sample data...")

--- a/examples/dual_embedding/main.go
+++ b/examples/dual_embedding/main.go
@@ -24,11 +24,11 @@ func main() {
 	// Step 1: Create dimension reducer using factory pattern
 	reductionConfig := reduction.DimensionReducerConfig{
 		ReducerConfig: reduction.ReducerConfig{
-			OutputDimensions: 384,  // 75% reduction  
+			OutputDimensions: 384,  // 75% reduction
 			VarianceRetained: 0.95, // Retain 95% variance
 		},
-		Type:               reduction.PCAReducerType,  // Use standard PCA
-		EnableOptimization: false,                     // Use standard implementation for demo
+		Type:               reduction.PCAReducerType, // Use standard PCA
+		EnableOptimization: false,                    // Use standard implementation for demo
 	}
 
 	reducer, err := reduction.NewDimensionReducerWithFactory(reductionConfig)
@@ -38,11 +38,14 @@ func main() {
 
 	// Step 2: Create cache with dimension reduction
 	// This automatically enables dual embedding storage
-	cache := core.NewCache(1000,
+	cache, err := core.NewCache(1000,
 		core.WithEmbeddingFunc(embedFunc),
 		core.WithDimensionReduction(reducer),
 		core.WithMinSimilarity(0.8),
 	)
+	if err != nil {
+		log.Fatalf("failed to create cache: %v", err)
+	}
 
 	ctx := context.Background()
 

--- a/examples/factory_pattern/main.go
+++ b/examples/factory_pattern/main.go
@@ -91,11 +91,15 @@ func main() {
 		}
 
 		// Create cache with the reducer
-		cache := core.NewCache(100,
+		cache, err := core.NewCache(100,
 			core.WithEmbeddingFunc(embedFunc),
 			core.WithDimensionReduction(reducer),
 			core.WithMinSimilarity(0.8),
 		)
+		if err != nil {
+			log.Printf("failed to create cache: %v", err)
+			continue
+		}
 
 		// Populate cache
 		fmt.Printf("Populating cache...\n")

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -9,7 +9,10 @@ import (
 
 func main() {
 	// Create an in-memory cache with capacity of 100
-	cache := core.NewCache(100)
+	cache, err := core.NewCache(100)
+	if err != nil {
+		panic(err)
+	}
 
 	// Store a prompt-response pair
 	cache.Set("What is AI?", nil, "Artificial Intelligence is...")

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -11,7 +11,10 @@ import (
 )
 
 func TestServerSetGet(t *testing.T) {
-	cache := core.NewCache(10)
+	cache, err := core.NewCache(10)
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
 	srv := New(cache)
 
 	ts := httptest.NewServer(srv)
@@ -42,9 +45,12 @@ func TestServerSetGet(t *testing.T) {
 // TestServerQuery ensures /query returns the correct answer for a given embedding.
 func TestServerQuery(t *testing.T) {
 	// build cache with two entries
-	cache := core.NewCache(2,
+	cache, err := core.NewCache(2,
 		core.WithSimilarityFunc(core.InnerProduct),
 	)
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
 	cache.Set("x", []float32{1, 0}, "AnswerX")
 	cache.Set("y", []float32{0, 1}, "AnswerY")
 	srv := New(cache)
@@ -70,9 +76,12 @@ func TestServerQuery(t *testing.T) {
 
 // TestServerTopK ensures /topk returns the top K results.
 func TestServerTopK(t *testing.T) {
-	cache := core.NewCache(3,
+	cache, err := core.NewCache(3,
 		core.WithSimilarityFunc(core.InnerProduct),
 	)
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
 	data := map[string][]float32{
 		"a": {1, 0},
 		"b": {0, 1},
@@ -108,7 +117,11 @@ func TestServerTopK(t *testing.T) {
 
 // TestServerHealth checks the /health endpoint.
 func TestServerHealth(t *testing.T) {
-	srv := New(core.NewCache(1))
+	cache, err := core.NewCache(1)
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
+	srv := New(cache)
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 	resp, err := http.Get(ts.URL + "/health")
@@ -119,7 +132,10 @@ func TestServerHealth(t *testing.T) {
 
 // TestServerMetrics checks the /metrics endpoint.
 func TestServerMetrics(t *testing.T) {
-	cache := core.NewCache(1)
+	cache, err := core.NewCache(1)
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
 	// generate one hit and one miss
 	cache.Set("p", []float32{1}, "a")
 	cache.Get("p")
@@ -141,7 +157,10 @@ func TestServerMetrics(t *testing.T) {
 }
 
 func TestServerFlush(t *testing.T) {
-	cache := core.NewCache(10)
+	cache, err := core.NewCache(10)
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
 	srv := New(cache)
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
@@ -159,7 +178,10 @@ func TestServerFlush(t *testing.T) {
 
 // Test that model metadata is stored and returned by the server.
 func TestServerModelMetadata(t *testing.T) {
-	cache := core.NewCache(10)
+	cache, err := core.NewCache(10)
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
 	srv := New(cache)
 	ts := httptest.NewServer(srv)
 	defer ts.Close()

--- a/storage/factory.go
+++ b/storage/factory.go
@@ -79,7 +79,11 @@ func newMemoryBackend(cfg *config.Config, embedFunc core.EmbeddingFunc) (core.Ca
 
 	if cfg != nil {
 		if cfg.Cache.EvictionPolicy != "" {
-			opts = append(opts, core.WithEvictionPolicy(cfg.Cache.EvictionPolicy))
+			polOpt, err := core.WithEvictionPolicy(cfg.Cache.EvictionPolicy)
+			if err != nil {
+				return nil, err
+			}
+			opts = append(opts, polOpt)
 		}
 		if ttl := cfg.TTLDuration(); ttl > 0 {
 			opts = append(opts, core.WithTTL(ttl))
@@ -89,7 +93,11 @@ func newMemoryBackend(cfg *config.Config, embedFunc core.EmbeddingFunc) (core.Ca
 		}
 	}
 
-	return core.NewCache(capacity, opts...), nil
+	cache, err := core.NewCache(capacity, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return cache, nil
 }
 
 // newRedisBackend creates a Redis cluster cache backend

--- a/storage/factory_test.go
+++ b/storage/factory_test.go
@@ -62,7 +62,11 @@ func TestFactory_NewBackend(t *testing.T) {
 func TestFactory_Register(t *testing.T) {
 	// Create a mock factory
 	mockFactory := func(cfg *config.Config, embedFunc core.EmbeddingFunc) (core.CacheBackend, error) {
-		return core.NewCache(10), nil
+		cache, err := core.NewCache(10)
+		if err != nil {
+			return nil, err
+		}
+		return cache, nil
 	}
 
 	// Register it


### PR DESCRIPTION
## Summary
Change cache construction to return errors instead of panicking.

## Changes Made
- `NewCache` returns `(*Cache, error)` and validates capacity
- `WithEvictionPolicy` returns error on unknown policy
- Updated factory and tests to handle new APIs

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6856452bd9448325a1e6b20e0a875f29