### PR TITLE
openai: close chat stream

### DIFF
--- a/openai/client.go
+++ b/openai/client.go
@@ -250,6 +250,7 @@ func (c *Client) ChatStream(ctx context.Context, messages []ChatMessage, opts Ch
 	go func() {
 		defer close(out)
 		defer close(errChan)
+		defer stream.Close()
 		for stream.Next() {
 			chunk := stream.Current()
 			if len(chunk.Choices) > 0 {

--- a/openai/client_test.go
+++ b/openai/client_test.go
@@ -3,10 +3,14 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	openai "github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
 )
 
 func TestComplete(t *testing.T) {
@@ -116,5 +120,56 @@ func TestClientConfig(t *testing.T) {
 	c.ConfigureAzure("k3", "http://x", "2023-09-01")
 	if c.BaseURL != "http://x" || c.APIVersion != "2023-09-01" || c.apiKey != "k3" {
 		t.Fatalf("azure config not applied")
+	}
+}
+
+// TestChatStreamClose verifies that the streaming connection is closed after
+// processing completes.
+type mockBody struct {
+	io.Reader
+	closed bool
+}
+
+func (m *mockBody) Close() error {
+	m.closed = true
+	return nil
+}
+
+type mockRoundTripper struct {
+	body *mockBody
+}
+
+func (m *mockRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	data := "data: {\"choices\": [{\"delta\": {\"content\": \"hi\"}}]}\n\ndata: [DONE]\n\n"
+	body := &mockBody{Reader: strings.NewReader(data)}
+	m.body = body
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       body,
+	}, nil
+}
+
+// TestChatStreamClose verifies that Close is called on the underlying stream.
+func TestChatStreamClose(t *testing.T) {
+	rt := &mockRoundTripper{}
+	httpClient := &http.Client{Transport: rt}
+	ai := openai.NewClient(option.WithAPIKey("test"), option.WithHTTPClient(httpClient))
+	c := &Client{apiKey: "test", client: ai}
+
+	out, errs, err := c.ChatStream(context.Background(), []ChatMessage{{Role: "user", Content: "hi"}}, ChatOptions{Model: "test"})
+	if err != nil {
+		t.Fatalf("ChatStream returned error: %v", err)
+	}
+	if msg := <-out; msg != "hi" {
+		t.Fatalf("unexpected message %q", msg)
+	}
+	for range out {
+	}
+	if err := <-errs; err != nil {
+		t.Fatalf("stream error: %v", err)
+	}
+	if !rt.body.closed {
+		t.Fatalf("expected stream to be closed")
 	}
 }


### PR DESCRIPTION
## Summary
Ensure OpenAI streaming connections are properly closed and add a unit test.

## Changes Made
- Close the streaming response in `ChatStream` using `defer stream.Close()`
- Added `TestChatStreamClose` verifying the close operation

## Testing
- `go vet ./...`
- `go test ./openai -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6856476cf0908325853d278a0bcf6dbd