### PR TITLE
storage: sort tiers using sort.Slice

### DIFF
--- a/storage/composite.go
+++ b/storage/composite.go
@@ -3,6 +3,7 @@ package storage
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -56,13 +57,9 @@ type CompositeBackend struct {
 // NewCompositeBackend creates a new composite backend with configured tiers
 func NewCompositeBackend(tiers []*Tier, embedder core.EmbeddingFunc, threshold float64) *CompositeBackend {
 	// Sort tiers by priority
-	for i := 0; i < len(tiers)-1; i++ {
-		for j := i + 1; j < len(tiers); j++ {
-			if tiers[i].Priority > tiers[j].Priority {
-				tiers[i], tiers[j] = tiers[j], tiers[i]
-			}
-		}
-	}
+	sort.Slice(tiers, func(i, j int) bool {
+		return tiers[i].Priority < tiers[j].Priority
+	})
 
 	return &CompositeBackend{
 		tiers:        tiers,


### PR DESCRIPTION
## Summary
Refactor the composite backend constructor to use `sort.Slice` for ordering tiers.

## Changes Made
- Added `sort` import in `storage/composite.go`
- Replaced nested loops with `sort.Slice` for tier ordering

## Testing
- [x] `go vet ./...`
- [x] `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6856abd5e8b88325afc65d530ed82e39