### PR TITLE
cmd: initialize kubernetes client for tests

### DIFF
--- a/iaac/infra/cmd/test.go
+++ b/iaac/infra/cmd/test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/raja-aiml/sematic-cache/deploy/local/pkg/kubernetes"
 	"github.com/raja-aiml/sematic-cache/deploy/local/pkg/testing/framework"
 	"github.com/raja-aiml/sematic-cache/deploy/local/pkg/testing/reporters"
 	"github.com/raja-aiml/sematic-cache/deploy/local/pkg/testing/suites/integration"
@@ -100,8 +101,12 @@ func runTest(cmd *cobra.Command, args []string) error {
 
 	// Create test environment
 	logger := framework.NewSimpleLogger("test", testVerbose)
+	k8sClient, err := kubernetes.GetDefaultClient()
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
 	env := &framework.TestEnvironment{
-		KubeClient: nil, // TODO: Initialize kubernetes client
+		KubeClient: k8sClient,
 		Config:     config,
 		Logger:     logger,
 		Context:    make(map[string]interface{}),


### PR DESCRIPTION
## Summary
Initialize Kubernetes client in the `iaac test` command using the default client factory.

## Changes Made
- Added kubernetes package import in `iaac/infra/cmd/test.go`
- Created client with `kubernetes.GetDefaultClient()` and attached to test environment

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6856ac95d7b08325a592cf3654435c7a